### PR TITLE
Shift the origin of the exponential smoother and add an exponential moving average filter

### DIFF
--- a/docs/source/tutorials/operations.rst
+++ b/docs/source/tutorials/operations.rst
@@ -89,9 +89,9 @@ Aditionally, a simple exponentially moving average filter is provided
 
 .. code-block:: python
 
-    from yupi.transformations import exponential_moving_average 
+    from yupi.transformations import exp_moving_average_filter 
     traj = Trajectory(points=[[1,2], [3,3], [4,2]])
-    smoothed_traj = exponential_moving_average(traj, alpha=1/100)
+    smoothed_traj = exp_moving_average_filter(traj, alpha=1/100)
 
 For trajectories with non-uniform time samples, a :py:class:`~tau` parameter must be provided and 
 an adaptive alpha parameter is calculated as alpha = 1- exp(-dt/\tau) for each time step.

--- a/docs/source/tutorials/operations.rst
+++ b/docs/source/tutorials/operations.rst
@@ -85,6 +85,17 @@ the context of animal trajectory analysis:
 
 
 
+Aditionally, a simple exponentially moving average filter is provided
+
+.. code-block:: python
+
+    from yupi.transformations import exponential_moving_average 
+    traj = Trajectory(points=[[1,2], [3,3], [4,2]])
+    smoothed_traj = exponential_moving_average(traj, alpha=1/100)
+
+For trajectories with non-uniform time samples, a :py:class:`~tau` parameter must be provided and 
+an adaptive alpha parameter is calculated as alpha = 1- exp(-dt/\tau) for each time step.
+
 Adding and subtracting
 ======================
 

--- a/tests/test_transformations/test_transformations.py
+++ b/tests/test_transformations/test_transformations.py
@@ -3,7 +3,7 @@ import pytest
 
 from yupi import Trajectory
 from yupi.transformations import resample, subsample
-from yupi.transformations import exponential_moving_average,exp_convolutional_filter 
+from yupi.transformations import exp_moving_average_filter,exp_convolutional_filter 
 
 
 @pytest.fixture
@@ -15,19 +15,16 @@ def x():
 def traj(x):
     return Trajectory(x=x)
 
-@pytest.fixture
-def initial_velocity():
-    return [1.0, 0.5, 0.2]  # Constant velocity [vx, vy, vz]
 
 @pytest.fixture
 def non_zero_origin():
     return [7, 7, 7]  # Initial position
 
 @pytest.fixture
-def contant_v_non_zero_origin_traj(non_zero_origin,initial_velocity):
+def constant_v_non_zero_origin_traj(non_zero_origin):
     num_steps = 500
     noise_std = 0.8  # Standard deviation of Gaussian noise
-    velocity = np.array(initial_velocity)
+    velocity = np.array([1.0, 0.5, 0.2])
     trajectory = np.zeros((num_steps, 3))
     trajectory[0] = non_zero_origin
     t_vals = list(range(num_steps))
@@ -67,13 +64,13 @@ def test_threshold():
     subsample(traj2)
 
 
-def test_exp_convolution_origin(contant_v_non_zero_origin_traj,
+def test_exp_convolution_origin(constant_v_non_zero_origin_traj,
                                 non_zero_origin):
-    smooted_trajectory = exp_convolutional_filter(contant_v_non_zero_origin_traj,1/100)
+    smooted_trajectory = exp_convolutional_filter(constant_v_non_zero_origin_traj,1/100)
     assert smooted_trajectory.r[0] == pytest.approx(non_zero_origin)
 
 
-def test_ema_origin(contant_v_non_zero_origin_traj,
+def test_ema_origin(constant_v_non_zero_origin_traj,
                                 non_zero_origin):
-    smooted_trajectory = exponential_moving_average(contant_v_non_zero_origin_traj,alpha=1/100)
+    smooted_trajectory = exp_moving_average_filter(constant_v_non_zero_origin_traj,alpha=1/100)
     assert smooted_trajectory.r[0] == pytest.approx(non_zero_origin)

--- a/tests/test_transformations/test_transformations.py
+++ b/tests/test_transformations/test_transformations.py
@@ -3,6 +3,7 @@ import pytest
 
 from yupi import Trajectory
 from yupi.transformations import resample, subsample
+from yupi.transformations import exponential_moving_average,exp_convolutional_filter 
 
 
 @pytest.fixture
@@ -14,6 +15,26 @@ def x():
 def traj(x):
     return Trajectory(x=x)
 
+@pytest.fixture
+def initial_velocity():
+    return [1.0, 0.5, 0.2]  # Constant velocity [vx, vy, vz]
+
+@pytest.fixture
+def non_zero_origin():
+    return [7, 7, 7]  # Initial position
+
+@pytest.fixture
+def contant_v_non_zero_origin_traj(non_zero_origin,initial_velocity):
+    num_steps = 500
+    noise_std = 0.8  # Standard deviation of Gaussian noise
+    velocity = np.array(initial_velocity)
+    trajectory = np.zeros((num_steps, 3))
+    trajectory[0] = non_zero_origin
+    t_vals = list(range(num_steps))
+    # Generate trajectory
+    for t in range(1,num_steps):
+        trajectory[t] = trajectory[t-1] + velocity * t + np.random.normal(0, noise_std, size=3)
+    return Trajectory(points=trajectory,t=t_vals)
 
 def test_subsample(x, traj):
     sub_sample = subsample(traj, 2)
@@ -44,3 +65,15 @@ def test_threshold():
     traj2 = Trajectory(x=np.arange(743), dt=dt)
     subsample(traj1)
     subsample(traj2)
+
+
+def test_exp_convolution_origin(contant_v_non_zero_origin_traj,
+                                non_zero_origin):
+    smooted_trajectory = exp_convolutional_filter(contant_v_non_zero_origin_traj,1/100)
+    assert smooted_trajectory.r[0] == pytest.approx(non_zero_origin)
+
+
+def test_ema_origin(contant_v_non_zero_origin_traj,
+                                non_zero_origin):
+    smooted_trajectory = exponential_moving_average(contant_v_non_zero_origin_traj,alpha=1/100)
+    assert smooted_trajectory.r[0] == pytest.approx(non_zero_origin)

--- a/yupi/transformations/__init__.py
+++ b/yupi/transformations/__init__.py
@@ -7,14 +7,14 @@ from ``yupi.transormations``.
 """
 
 from yupi.transformations._filters import exp_convolutional_filter
-from yupi.transformations._filters import exponential_moving_average
+from yupi.transformations._filters import exp_moving_average_filter
 from yupi.transformations._resamplers import resample, subsample
 from yupi.transformations._transformations import add_moving_FoR
 
 __all__ = [
     "subsample",
     "exp_convolutional_filter",
-    "exponential_moving_average",
+    "exp_moving_average_filter",
     "add_moving_FoR",
     "resample",
 ]

--- a/yupi/transformations/__init__.py
+++ b/yupi/transformations/__init__.py
@@ -7,12 +7,14 @@ from ``yupi.transormations``.
 """
 
 from yupi.transformations._filters import exp_convolutional_filter
+from yupi.transformations._filters import exponential_moving_average
 from yupi.transformations._resamplers import resample, subsample
 from yupi.transformations._transformations import add_moving_FoR
 
 __all__ = [
     "subsample",
     "exp_convolutional_filter",
+    "exponential_moving_average",
     "add_moving_FoR",
     "resample",
 ]

--- a/yupi/transformations/_filters.py
+++ b/yupi/transformations/_filters.py
@@ -47,7 +47,7 @@ def exp_convolutional_filter(
 
 
 
-def exponential_moving_average(
+def exp_moving_average_filter(
         traj: Trajectory, alpha: float,tau:Optional[float] = None, new_traj_id: Optional[str] = None
 ):
     """

--- a/yupi/transformations/_filters.py
+++ b/yupi/transformations/_filters.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from yupi.trajectory import Trajectory
 
+from yupi.trajectory import _THRESHOLD, Trajectory
 
 def exp_convolutional_filter(
     traj: Trajectory, gamma: float, new_traj_id: Optional[str] = None
@@ -32,7 +33,8 @@ def exp_convolutional_filter(
         Smoothed trajectory.
     """
 
-    r = traj.r
+    track_origin = traj.r[0]
+    r = (traj-track_origin).r
     dt = np.ediff1d(traj.t)
     new_r = np.zeros_like(r)
     for i in range(len(traj) - 1):
@@ -40,5 +42,60 @@ def exp_convolutional_filter(
 
     smooth_traj = Trajectory(
         points=new_r, t=traj.t, traj_id=new_traj_id, diff_est=traj.diff_est
+    )
+    return smooth_traj + track_origin
+
+
+
+def exponential_moving_average(
+        traj: Trajectory, alpha: float,tau:Optional[float] = None, new_traj_id: Optional[str] = None
+):
+    """
+    Returns a smoothed version of the trajectory `traj`
+    using the exponential moving average defined as
+
+    s(0) = x(0)
+    s(t_n) = alpha x(t_{n-1})  + (1-alpha) s(t_{n-1})
+
+    If the the trajectory times are non-uniform then tau must be provided. The non-uniform time filter is
+    computed as
+
+    s(0) = x(0)
+    alpha(t_n) = 1 - exp(-(t_n - t_{n-1}) / tau))
+    s(t_n) = alpha(t_n) x(t_{n-1})  + (1-alpha(t_n)) s(t_{n-1})
+    
+    Parameters
+    ----------
+    traj : Trajectory
+        Input trajectory.
+    alpha : float
+        Exponential smoothing paramter.
+    tau: float [optional, default=None]
+        Smoothing factor that must be provided if the trajectory timeseries is non-uniform.
+    new_traj_id : Optional[str]
+        New trajectory ID. By default None.
+
+    Returns
+    -------
+    Trajectory
+        Smoothed trajectory.
+    """
+    data = traj.r
+    times = traj.t
+    if tau is None and abs(traj.dt_std - 0) > _THRESHOLD:
+        raise ValueError("All trajectories must be uniformly time spaced if tau is not provided")        
+    n_times, _ = data.shape
+    ema = np.zeros_like(data)    
+    ema[0] = data[0]
+    # The uniform time smoother can likely be simplified with a convolution
+    # using scipy but I didn't want to bring in that dependency here
+    for i in range(1, n_times):
+        dt = times[i] - times[i - 1]
+        if tau is not None:
+            alpha = 1 - np.exp(-dt / tau)  # Adaptive smoothing factor
+        ema[i] = alpha * data[i] + (1 - alpha) * ema[i - 1]
+    
+    smooth_traj = Trajectory(
+        points=ema, t=traj.t, traj_id=new_traj_id, diff_est=traj.diff_est
     )
     return smooth_traj


### PR DESCRIPTION
## Exponention convolution Changes

The current bug in the exponential convolution filter can be observed using the following code:

```python
import numpy as np
import matplotlib.pyplot as plt
from yupi.transformations import exp_convolutional_filter
from yupi import Trajectory
# Parameters
num_steps = 5000  # Number of time steps
dt = 0.1  # Time step size
velocity = np.array([1.0, 0.5, 0.2])  # Constant velocity [vx, vy, vz]
noise_std = 0.8  # Standard deviation of Gaussian noise
# Initialize trajectory
trajectory = np.zeros((num_steps, 3))
trajectory[0] = [7, 7, 7]  # Initial position
t_vals = list(range(num_steps))
# Generate trajectory
for t in range(1,num_steps):
    trajectory[t] = trajectory[t-1] + velocity * t + np.random.normal(0, noise_std, size=3)

gamma = 1/12
track = Trajectory(x=trajectory[:,0],
                   y=trajectory[:,1],
                   z=trajectory[:,2])
smoothed_traj = exp_convolutional_filter(track, gamma)
plt.plot(t_vals,track.r[:,0],label='data')
plt.plot(smoothed_traj.r[:,0],label='smoothed')
plt.hlines(y=7,xmin=0,xmax=1000,color='r',linestyle='-.',label='origin')
plt.xlim(0,max(t_vals))
plt.ylabel('x')
plt.xlabel('t')
plt.xlim(0,20)
plt.ylim(0,20)
plt.legend()
```

This yields the following plot

![image](https://github.com/user-attachments/assets/aacfdabc-2434-433f-aaec-c3be31463246)

where one sees the origin incorrect. The changes address this origin mis-match. Additionally, what is the source of the filter used here? I have not been able to find this exact implementation in any of my discrete signal processing sources. It looks to be a Euler approximation to $dy/dt = -gamma(y-x_noisy)$ .

## EMA Addition

I also added an exponential moving average filter since it's an easy filter to add and wasn't there.